### PR TITLE
Fix conditional check of options.sameOrigin

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -36,9 +36,7 @@ export default class DD {
 
     this.urls = API_METHODS_URL[options.apiversion || 0.1];
 
-    if (
-      typeof options.sameOrigin
-    ) {
+    if (options.sameOrigin) {
       // Browser support, uses window.location by default
       this.ddurl = window.location.origin;
     } else {


### PR DESCRIPTION
- typeof always returns a truthy value ([MDN link](mdn instanceof vs typeof))

<!--- Provide a general summary of your changes in the Title above -->

## PR Type
<!--- What types of changes does your code introduce? -->
<!-- Put an `x` in all the boxes that apply: -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (whitespace, formatting, missing semicolons, etc.)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other… Please describe:

## Description
<!--- Describe your changes in detail -->
I changed the conditional check of options.sameOrigin in the constructor. The condition used to look at `typeof options.sameOrigin` which is always a truthy value (a string). Now it checks for the existence of the option directly. 

<!--- Why is this change required? What problem does it solve? -->
The change is required to run this library in a nodejs environment because the `window` global variable does not exist. 
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Before the code wouldn't run in a nodejs environment throwing the error `window is undefined`. Now the library works as advertised on nodejs environments.
<!--- Include details of your testing environment, and the tests you ran to -->
Tested on Noder 14.9.0 on a Mac in an electron app.
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, -->
<!-- please also describe the impact and migration path for existing applications -->
- [ ] Yes
- [x] No

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If you‘re unsure about any of these, don‘t hesitate to ask. We‘re here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [`contributing.md`](https://github.com/alx/deepdetect-js/blob/master/contributing.md).

^ there is no contributing.md
